### PR TITLE
[DFT/MKLGPU] MKLGPU work

### DIFF
--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -19,11 +19,11 @@
 
 #Build object from all sources
 set(DFTI_CT_SOURCES "")
-if(ENABLE_MKLCPU_BACKEND)
-  list(APPEND DFTI_CT_SOURCES "complex_fwd_usm_mklcpu")
+if(ENABLE_MKLGPU_BACKEND)
+  list(APPEND DFTI_CT_SOURCES "complex_fwd_buffer_mklgpu")
 endif()
 
-if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND)
+if(domain STREQUAL "dft" AND ENABLE_MKLGPU_BACKEND)
   find_library(OPENCL_LIBRARY NAMES OpenCL)
   message(STATUS "Found OpenCL: ${OPENCL_LIBRARY}")
 endif()
@@ -35,9 +35,9 @@ foreach(dfti_ct_sources ${DFTI_CT_SOURCES})
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
   )
-  if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND)
-    add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklcpu)
-    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklcpu)
+  if(domain STREQUAL "dft" AND ENABLE_MKLGPU_BACKEND)
+    add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklgpu)
+    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklgpu)
     target_link_libraries(example_${domain}_${dfti_ct_sources} PUBLIC ${OPENCL_LIBRARY})
   endif()
   target_link_libraries(example_${domain}_${dfti_ct_sources} PUBLIC

--- a/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
@@ -17,23 +17,8 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-/*
-*
-*  Content:
-*       This example demonstrates use of oneapi::mkl::dft::getrf and
-*       oneapi::mkl::dft::getrs to perform LU factorization and compute
-*       the solution on both an Intel cpu device and NVIDIA cpu device.
-*
-*       This example demonstrates only single precision (float) data type
-*       for matrix data
-*
-*******************************************************************************/
-
 // STL includes
-#include <algorithm>
-#include <cstdlib>
 #include <iostream>
-#include <vector>
 
 // oneMKL/SYCL includes
 #if __has_include(<sycl/sycl.hpp>)
@@ -43,80 +28,76 @@
 #endif
 #include "oneapi/mkl.hpp"
 
-// local includes
-#include "example_helper.hpp"
+void run_example(const sycl::device& gpu_device) {
+    constexpr int N = 10;
 
-void run_getrs_example(const sycl::device& cpu_device) {
-    // Matrix sizes and leading dimensions
-    constexpr std::size_t N = 10;
-    std::int64_t rs[3] {0, N, 1};
-
-
-    // Catch asynchronous exceptions for cpu and cpu
-    auto cpu_error_handler = [&](sycl::exception_list exceptions) {
+    // Catch asynchronous exceptions for cpu
+    auto gpu_error_handler = [&](sycl::exception_list exceptions) {
         for (auto const& e : exceptions) {
             try {
                 std::rethrow_exception(e);
             }
             catch (sycl::exception const& e) {
                 // Handle not dft related exceptions that happened during asynchronous call
-                std::cerr
-                    << "Caught asynchronous SYCL exception on cpu device during GETRF or GETRS:"
-                    << std::endl;
+                std::cerr << "Caught asynchronous SYCL exception:" << std::endl;
                 std::cerr << "\t" << e.what() << std::endl;
             }
         }
         std::exit(2);
     };
 
-    std::cout << "DFTI example" << std::endl;
-    //
-    // Preparation on cpu
-    //
-    sycl::queue cpu_queue(cpu_device, cpu_error_handler);
-    sycl::context cpu_context = cpu_queue.get_context();
-    sycl::event cpu_getrf_done;
+    sycl::queue gpu_queue(gpu_device, gpu_error_handler);
 
-    double *x_usm = (double*) malloc_shared(N*2*sizeof(double), cpu_queue.get_device(), cpu_queue.get_context());
+    std::vector<std::complex<float>> input_data(N);
+    std::vector<std::complex<float>> output_data(N);
 
     // enabling
-    // 1. create descriptors 
-    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX> desc(N);
+    // 1. create descriptors
+    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
+                                 oneapi::mkl::dft::domain::COMPLEX>
+        desc(N);
 
     // 2. variadic set_value
-    desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT, oneapi::mkl::dft::config_value::NOT_INPLACE);
+    desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
+                   oneapi::mkl::dft::config_value::NOT_INPLACE);
+    desc.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   static_cast<std::int64_t>(1));
 
-    // 3. commit_descriptor (compile_time CPU)
-    desc.commit(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklcpu>{ cpu_queue });
+    // 3. commit_descriptor (compile_time MKLGPU)
+    desc.commit(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklgpu>{ gpu_queue });
 
-    // 5. compute_forward / compute_backward (CPU)
-    // oneapi::mkl::dft::compute_forward(desc, x_usm);
+    // 4. compute_forward / compute_backward (MKLGPU)
+    {
+        sycl::buffer<std::complex<float>> input_buffer(input_data.data(), sycl::range<1>(N));
+        sycl::buffer<std::complex<float>> output_buffer(output_data.data(), sycl::range<1>(N));
+        oneapi::mkl::dft::mklgpu::compute_forward<decltype(desc), std::complex<float>,
+                                                  std::complex<float>>(desc, input_buffer,
+                                                                       output_buffer);
+    }
 }
 
 //
 // Description of example setup, apis used and supported floating point type precisions
 //
-
 void print_example_banner() {
     std::cout << "" << std::endl;
     std::cout << "########################################################################"
               << std::endl;
-    std::cout
-        << "# DFTI complex in-place forward transform for USM/Buffer API's example: "
-        << std::endl;
+    std::cout << "# Complex out-of-place forward transform for Buffer API's example: " << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using APIs:" << std::endl;
-    std::cout << "#   USM/BUffer forward complex in-place" << std::endl;
+    std::cout << "#   Compile-time dispatch API" << std::endl;
+    std::cout << "#   Buffer forward complex out-of-place" << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using single precision (float) data type" << std::endl;
     std::cout << "# " << std::endl;
-    std::cout << "# Device will be selected during runtime." << std::endl;
+    std::cout << "# Using single precision (float) data type" << std::endl;
+    std::cout << "# " << std::endl;
+    std::cout << "# For Intel GPU with Intel MKLGPU backend." << std::endl;
+    std::cout << "# " << std::endl;
     std::cout << "# The environment variable SYCL_DEVICE_FILTER can be used to specify"
               << std::endl;
-    std::cout << "# Using single precision (float) data type" << std::endl;
-    std::cout << "# " << std::endl;
-    std::cout << "# Running on both Intel cpu and NVIDIA cpu devices" << std::endl;
-    std::cout << "# " << std::endl;
+    std::cout << "# SYCL device" << std::endl;
     std::cout << "########################################################################"
               << std::endl;
     std::cout << std::endl;
@@ -129,13 +110,15 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device cpu_dev((sycl::cpu_selector_v));
-        std::cout << "Running DFT Complex forward inplace USM example" << std::endl;
+        sycl::device gpu_device((sycl::gpu_selector_v));
+        std::cout << "Running DFT Complex forward out-of-place buffer example" << std::endl;
+        std::cout << "Using compile-time dispatch API with MKLGPU." << std::endl;
         std::cout << "Running with single precision real data type on:" << std::endl;
-        std::cout << "\tcpu device :" << cpu_dev.get_info<sycl::info::device::name>() << std::endl;
+        std::cout << "\tGPU device :" << gpu_device.get_info<sycl::info::device::name>()
+                  << std::endl;
 
-        run_getrs_example(cpu_dev);
-        std::cout << "DFT Complex USM example ran OK on MKLcpu" << std::endl;
+        run_example(gpu_device);
+        std::cout << "DFT Complex USM example ran OK on MKLGPU" << std::endl;
     }
     catch (sycl::exception const& e) {
         // Handle not dft related exceptions that happened during synchronous call

--- a/examples/dft/run_time_dispatching/CMakeLists.txt
+++ b/examples/dft/run_time_dispatching/CMakeLists.txt
@@ -20,7 +20,7 @@
 # NOTE: user needs to set env var SYCL_DEVICE_FILTER to use runtime example (no need to specify backend when building with CMake)
 
 # Build object from all example sources
-set(DFT_RT_SOURCES "complex_fwd_usm")
+set(DFT_RT_SOURCES "real_fwd_usm")
 
 # Set up for the right backend for run-time dispatching examples
 # If users build more than one backend (i.e. mklcpu and mklgpu, or mklcpu and CUDA), they may need to
@@ -29,8 +29,7 @@ set(DEVICE_FILTERS "")
 if(ENABLE_MKLCPU_BACKEND)
   list(APPEND DEVICE_FILTERS "cpu")
 endif()
-# RNG only supports mklcpu backend on Windows
-if(UNIX AND ENABLE_MKLGPU_BACKEND)
+if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DEVICE_FILTERS "gpu")
 endif()
 

--- a/examples/dft/run_time_dispatching/real_fwd_usm.cpp
+++ b/examples/dft/run_time_dispatching/real_fwd_usm.cpp
@@ -1,9 +1,25 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
 
 // stl includes
-#include <algorithm>
-#include <cstdlib>
 #include <iostream>
-#include <vector>
+#include <cstdint>
 
 // oneMKL/SYCL includes
 #if __has_include(<sycl/sycl.hpp>)
@@ -11,22 +27,11 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+
 #include "oneapi/mkl.hpp"
 
-// local includes
-#include "example_helper.hpp"
-
-constexpr int SUCCESS = 0;
-constexpr int FAILURE = 1;
-constexpr double TWOPI = 6.2831853071795864769;
-
-void run_uniform_example(const sycl::device& dev) {
-
+void run_example(const sycl::device& dev) {
     int N = 16;
-    int harmonic = 5;
-    int buffer_result = FAILURE;
-    int usm_result = FAILURE;
-    int result = FAILURE;
 
     // Catch asynchronous exceptions
     auto exception_handler = [](sycl::exception_list exceptions) {
@@ -35,40 +40,41 @@ void run_uniform_example(const sycl::device& dev) {
                 std::rethrow_exception(e);
             }
             catch (sycl::exception const& e) {
-                std::cerr << "Caught asynchronous SYCL exception during generation:" << std::endl;
+                std::cerr << "Caught asynchronous SYCL exception:" << std::endl;
                 std::cerr << "\t" << e.what() << std::endl;
             }
         }
         std::exit(2);
     };
 
-    sycl::queue queue(dev, exception_handler);
+    std::cout << "DFT example run_time dispatch" << std::endl;
 
-    std::cout << "DFTI example run_time dispatch" << std::endl;
-    //
-    // Preparation on cpu
-    //
-    sycl::queue cpu_queue(dev, exception_handler);
-    sycl::context cpu_context = cpu_queue.get_context();
-    sycl::event cpu_getrf_done;
+    sycl::queue sycl_queue(dev, exception_handler);
+    auto x_usm = sycl::malloc_shared<float>(N * 2, sycl_queue);
 
-    double *x_usm = (double*) malloc_shared(N*2*sizeof(double), cpu_queue.get_device(), cpu_queue.get_context());
-
-    // enabling
-    // 1. create descriptors 
-    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX> desc_vector({N,N});
+    // 1. create descriptors
+    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
+                                 oneapi::mkl::dft::domain::REAL>
+        desc(N);
 
     // 2. variadic set_value
-    desc_vector.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (double)(1.0/N));
-    desc_vector.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, 4);
-    desc_vector.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, N);
-    desc_vector.set_value(oneapi::mkl::dft::config_param::PLACEMENT, oneapi::mkl::dft::config_value::NOT_INPLACE);
+    desc.set_value(oneapi::mkl::dft::config_param::FORWARD_SCALE, 1.f / N);
+    desc.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   static_cast<std::int64_t>(1));
+    desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
+                   oneapi::mkl::dft::config_value::INPLACE);
 
-    // 4. commit_descriptor (run_time xPU)
-    desc_vector.commit(cpu_queue);
+    // 3. commit_descriptor (runtime dispatch)
+    desc.commit(sycl_queue);
 
-    // 5. compute_forward / compute_backward (CPU)
-    // oneapi::mkl::dft::compute_forward(desc, x_usm);
+    // 4. compute_forward / compute_backward (runtime dispatch)
+    auto compute_event = oneapi::mkl::dft::compute_forward(desc, x_usm);
+
+    // Do something with transformed data.
+    compute_event.wait();
+
+    // 5. Free USM allocation.
+    sycl::free(x_usm, sycl_queue);
 }
 
 //
@@ -78,12 +84,11 @@ void print_example_banner() {
     std::cout << "" << std::endl;
     std::cout << "########################################################################"
               << std::endl;
-    std::cout
-        << "# DFTI complex in-place forward transform for USM/Buffer API's example: "
-        << std::endl;
+    std::cout << "# DFTI complex in-place forward transform with USM API example: " << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using APIs:" << std::endl;
-    std::cout << "#   USM/BUffer forward complex in-place" << std::endl;
+    std::cout << "#   USM forward complex in-place" << std::endl;
+    std::cout << "#   Run-time dispatch" << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using single precision (float) data type" << std::endl;
     std::cout << "# " << std::endl;
@@ -105,7 +110,7 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device my_dev((sycl::default_selector_v));
+        sycl::device my_dev((sycl::default_selector()));
 
         if (my_dev.is_gpu()) {
             std::cout << "Running DFT complex forward example on GPU device" << std::endl;
@@ -119,8 +124,8 @@ int main(int argc, char** argv) {
         }
         std::cout << "Running with single precision real data type:" << std::endl;
 
-        run_uniform_example(my_dev);
-        std::cout << "DFIT example ran OK" << std::endl;
+        run_example(my_dev);
+        std::cout << "DFT example ran OK" << std::endl;
     }
     catch (sycl::exception const& e) {
         std::cerr << "Caught synchronous SYCL exception:" << std::endl;
@@ -129,7 +134,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     catch (std::exception const& e) {
-        std::cerr << "Caught std::exception during generation:" << std::endl;
+        std::cerr << "Caught std::exception:" << std::endl;
         std::cerr << "\t" << e.what() << std::endl;
         return 1;
     }

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -27,6 +27,8 @@
 #include <CL/sycl.hpp>
 #endif
 
+#include "oneapi/mkl/detail/backends.hpp"
+
 namespace oneapi {
 namespace mkl {
 namespace dft {
@@ -34,18 +36,31 @@ namespace detail {
 
 class commit_impl {
 public:
-    commit_impl(sycl::queue queue) : queue_(queue), status(false) {}
+    commit_impl(sycl::queue queue, mkl::backend backend)
+            : queue_(queue),
+              backend_(backend),
+              status(false) {}
 
-    commit_impl(const commit_impl& other) : queue_(other.queue_), status(other.status) {}
+    commit_impl(const commit_impl& other)
+            : queue_(other.queue_),
+              backend_(other.backend_),
+              status(other.status) {}
 
-    virtual ~commit_impl() {}
+    virtual ~commit_impl() = default;
 
     sycl::queue& get_queue() {
         return queue_;
     }
 
+    mkl::backend& get_backend() {
+        return backend_;
+    }
+
+    virtual void* get_handle() = 0;
+
 protected:
     bool status;
+    mkl::backend backend_;
     sycl::queue queue_;
 };
 

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -68,19 +68,13 @@ public:
     void commit(backend_selector<backend::mklgpu> selector);
 #endif
 
-    sycl::queue& get_queue() {
-        return queue_;
-    };
     dft_values<prec, dom> get_values() {
         return values_;
     };
 
 private:
-    std::unique_ptr<commit_impl> pimpl_; // commit only
-    sycl::queue queue_;
-
-    std::int64_t rank_;
-    std::vector<std::int64_t> dimensions_;
+    // Has a value when the descriptor is committed.
+    std::unique_ptr<commit_impl> pimpl_;
 
     // descriptor configuration values_ and structs
     dft_values<prec, dom> values_;

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -36,6 +36,12 @@ namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace detail {
+// Forward declaration:
+template <precision prec, domain dom>
+class descriptor;
+
+template <precision prec, domain dom>
+inline commit_impl* get_commit(descriptor<prec, dom>& desc);
 
 template <precision prec, domain dom>
 class descriptor {
@@ -70,7 +76,7 @@ public:
     };
 
 private:
-    std::unique_ptr<detail::commit_impl> pimpl_; // commit only
+    std::unique_ptr<commit_impl> pimpl_; // commit only
     sycl::queue queue_;
 
     std::int64_t rank_;
@@ -78,7 +84,14 @@ private:
 
     // descriptor configuration values_ and structs
     dft_values<prec, dom> values_;
+
+    friend commit_impl* get_commit<prec, dom>(descriptor<prec, dom>&);
 };
+
+template <precision prec, domain dom>
+inline commit_impl* get_commit(descriptor<prec, dom>& desc) {
+    return desc.pimpl_.get();
+}
 
 } // namespace detail
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -65,7 +65,7 @@ public:
     sycl::queue& get_queue() {
         return queue_;
     };
-    dft_values get_values() {
+    dft_values<prec, dom> get_values() {
         return values_;
     };
 
@@ -77,7 +77,7 @@ private:
     std::vector<std::int64_t> dimensions_;
 
     // descriptor configuration values_ and structs
-    dft_values values_;
+    dft_values<prec, dom> values_;
 };
 
 } // namespace detail

--- a/include/oneapi/mkl/dft/detail/dft_ct.hxx
+++ b/include/oneapi/mkl/dft/detail/dft_ct.hxx
@@ -20,7 +20,8 @@
 // Commit
 
 template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl *create_commit(dft::detail::descriptor<prec, dom> &desc);
+ONEMKL_EXPORT dft::detail::commit_impl *create_commit(dft::detail::descriptor<prec, dom> &desc,
+                                                      sycl::queue &sycl_queue);
 
 // BUFFER version
 

--- a/include/oneapi/mkl/dft/detail/dft_ct.hxx
+++ b/include/oneapi/mkl/dft/detail/dft_ct.hxx
@@ -1,0 +1,119 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Commit
+
+template <dft::detail::precision prec, dft::detail::domain dom>
+ONEMKL_EXPORT dft::detail::commit_impl *create_commit(dft::detail::descriptor<prec, dom> &desc);
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout);
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im);
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out);
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im);
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout);
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im);
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out);
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im);
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/dft/detail/dft_loader.hpp
+++ b/include/oneapi/mkl/dft/detail/dft_loader.hpp
@@ -20,6 +20,12 @@
 #ifndef _ONEMKL_DFT_LOADER_HPP_
 #define _ONEMKL_DFT_LOADER_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
 
@@ -34,7 +40,7 @@ template <precision prec, domain dom>
 class descriptor;
 
 template <precision prec, domain dom>
-ONEMKL_EXPORT commit_impl* create_commit(descriptor<prec, dom>& desc);
+ONEMKL_EXPORT commit_impl* create_commit(descriptor<prec, dom>& desc, sycl::queue& queue);
 
 } // namespace detail
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
@@ -20,6 +20,12 @@
 #ifndef _ONEMKL_DFT_MKLCPU_HPP_
 #define _ONEMKL_DFT_MKLCPU_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
 
@@ -36,8 +42,8 @@ class descriptor;
 } // namespace detail
 
 namespace mklcpu {
-template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc);
+
+#include "oneapi/mkl/dft/detail/dft_ct.hxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
@@ -20,7 +20,6 @@
 #ifndef _ONEMKL_DFT_MKLGPU_HPP_
 #define _ONEMKL_DFT_MKLGPU_HPP_
 
-#include <cstdint>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
@@ -43,8 +42,8 @@ class descriptor;
 } // namespace detail
 
 namespace mklgpu {
-template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc);
+
+#include "oneapi/mkl/dft/detail/dft_ct.hxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <type_traits>
 
 namespace oneapi {
 namespace mkl {
@@ -63,6 +64,7 @@ enum class config_param {
     PACKED_FORMAT,
     COMMIT_STATUS
 };
+
 enum class config_value {
     // for config_param::COMMIT_STATUS
     COMMITTED,
@@ -87,32 +89,36 @@ enum class config_value {
     ALLOW,
     AVOID,
     NONE,
-    WORKSPACE_INTERNAL,
-    WORKSPACE_EXTERNAL,
 
     // for config_param::PACKED_FORMAT for storing conjugate-even finite sequence in real containers
     CCE_FORMAT
-
 };
 
-struct dft_values {
+template <precision prec, domain dom>
+class dft_values {
+private:
+    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
+
+public:
     std::vector<std::int64_t> input_strides;
     std::vector<std::int64_t> output_strides;
-    double bwd_scale;
-    double fwd_scale;
+    real_t bwd_scale;
+    real_t fwd_scale;
     std::int64_t number_of_transforms;
     std::int64_t fwd_dist;
     std::int64_t bwd_dist;
     config_value placement;
     config_value complex_storage;
+    config_value real_storage;
     config_value conj_even_storage;
     config_value workspace;
-
+    config_value ordering;
+    bool transpose;
+    config_value packed_format;
     std::vector<std::int64_t> dimensions;
     std::int64_t rank;
-    domain domain;
-    precision precision;
 };
+
 } // namespace detail
 } // namespace dft
 } // namespace mkl

--- a/include/oneapi/mkl/dft/types.hpp
+++ b/include/oneapi/mkl/dft/types.hpp
@@ -33,7 +33,6 @@ using precision = detail::precision;
 using domain = detail::domain;
 using config_param = detail::config_param;
 using config_value = detail::config_value;
-using dft_values = detail::dft_values;
 using DFT_ERROR = detail::DFT_ERROR;
 
 } // namespace dft

--- a/src/dft/backends/CMakeLists.txt
+++ b/src/dft/backends/CMakeLists.txt
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-# if(ENABLE_MKLGPU_BACKEND)
-#   add_subdirectory(mklgpu)
-# endif()
+if(ENABLE_MKLGPU_BACKEND)
+  add_subdirectory(mklgpu)
+endif()
 
 if(ENABLE_MKLCPU_BACKEND)
   add_subdirectory(mklcpu)

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -27,31 +27,49 @@
 #define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
 #define DEPENDS_VEC_T const std::vector<sycl::event> &
 
-#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
-    /* Buffer API */                                                                          \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                   \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                     \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);          \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                       \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                 \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                  \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                      \
-                                                                                              \
-    /* USM API */                                                                             \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(            \
-        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                    \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>( \
-        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                       \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                              \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
+    /* Buffer API */                                                                            \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
+                                                                       sycl::buffer<REAL_T> &); \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                     \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                       \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(          \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);            \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                         \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                    \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                        \
+                                                                                                \
+    /* USM API */                                                                               \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, DEPENDS_VEC_T);                                          \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(              \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                      \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(   \
+        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                         \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                                \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                                \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
+    /* Buffer API */                                                                         \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);          \
+    /* USM API */                                                                            \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
+        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, DEPENDS_VEC_T);
+
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, std::complex<double>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_BACKWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#define DOM_REAL      dft::detail::domain::REAL
+#define DOM_COMPLEX   dft::detail::domain::COMPLEX
+#define PREC_F        dft::detail::precision::SINGLE
+#define PREC_D        dft::detail::precision::DOUBLE
+#define DESC_RF       dft::detail::descriptor<PREC_F, DOM_REAL>
+#define DESC_CF       dft::detail::descriptor<PREC_F, DOM_COMPLEX>
+#define DESC_RD       dft::detail::descriptor<PREC_D, DOM_REAL>
+#define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
+#define DEPENDS_VEC_T const std::vector<sycl::event> &
+
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
+    /* Buffer API */                                                                          \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                   \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                     \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);          \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                       \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                 \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                  \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                      \
+                                                                                              \
+    /* USM API */                                                                             \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(            \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                    \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>( \
+        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                       \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                              \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
+
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
+
+#undef ONEMKL_DFT_BACKWARD_INSTANTIATIONS
+#undef DOM_REAL
+#undef DOM_COMPLEX
+#undef PREC_F32
+#undef PREC_F64
+#undef DESC_RF32
+#undef DESC_CF32
+#undef DESC_RF64
+#undef DESC_CF64
+#undef DEPENDS_VEC_T

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -1,0 +1,66 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#define DOM_REAL      dft::detail::domain::REAL
+#define DOM_COMPLEX   dft::detail::domain::COMPLEX
+#define PREC_F        dft::detail::precision::SINGLE
+#define PREC_D        dft::detail::precision::DOUBLE
+#define DESC_RF       dft::detail::descriptor<PREC_F, DOM_REAL>
+#define DESC_CF       dft::detail::descriptor<PREC_F, DOM_COMPLEX>
+#define DESC_RD       dft::detail::descriptor<PREC_D, DOM_REAL>
+#define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
+#define DEPENDS_VEC_T const std::vector<sycl::event> &
+
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
+    /* Buffer API */                                                                         \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T>(                    \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &);                                     \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);         \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                       \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                 \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                     \
+                                                                                             \
+    /* USM API */                                                                            \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T>(             \
+        DESCRIPTOR_T & desc, FORWARD_T *, DEPENDS_VEC_T);                                    \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>( \
+        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                      \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                             \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
+
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
+
+#undef ONEMKL_DFT_FORWARD_INSTANTIATIONS
+#undef DOM_REAL
+#undef DOM_COMPLEX
+#undef PREC_F32
+#undef PREC_F64
+#undef DESC_RF32
+#undef DESC_CF32
+#undef DESC_RF64
+#undef DESC_CF64
+#undef DEPENDS_VEC_T

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -27,31 +27,49 @@
 #define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
 #define DEPENDS_VEC_T const std::vector<sycl::event> &
 
-#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
-    /* Buffer API */                                                                         \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T>(                    \
-        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &);                                     \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);         \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                       \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                 \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                     \
-                                                                                             \
-    /* USM API */                                                                            \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T>(             \
-        DESCRIPTOR_T & desc, FORWARD_T *, DEPENDS_VEC_T);                                    \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>( \
-        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                      \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                             \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
+    /* Buffer API */                                                                           \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
+                                                                      sycl::buffer<REAL_T> &); \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T>(                     \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                      \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(          \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);           \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                         \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                   \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                       \
+                                                                                               \
+    /* USM API */                                                                              \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, DEPENDS_VEC_T);                                         \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T>(              \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                     \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(   \
+        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                        \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
+    /* Buffer API */                                                                        \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);         \
+    /* USM API */                                                                           \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
+        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, DEPENDS_VEC_T);
+
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, std::complex<double>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_FORWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+/*
+This file lists functions matching those required by dft_function_table_t in 
+src/dft/function_table.hpp.
+
+To use this:
+
+#define WRAPPER_VERSION <Wrapper version number>
+#define BACKEND         <Backend name eg. mklgpu>
+
+extern "C" dft_function_table_t mkl_dft_table = {
+    WRAPPER_VERSION,
+#include "dft/backends/backend_wrappers.cxx"
+};
+
+Changes to this file should be matched to changes in function_table.hpp. The required 
+function template instantiations must be added to backend_backward_instantiations.cxx 
+and backend_forward_instantiations.cxx.
+*/
+
+// clang-format off
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \
+    /* Buffer API */                                                                         \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* USM API */                                                               \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* Buffer API */                                                            \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* USM API */                                                               \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
+
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                  oneapi::mkl::dft::detail::domain::REAL, float, float,
+                                  std::complex<float>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                  oneapi::mkl::dft::detail::domain::COMPLEX, float,
+                                  std::complex<float>, std::complex<float>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                  oneapi::mkl::dft::detail::domain::REAL, double,
+                                  double, std::complex<double>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                  oneapi::mkl::dft::detail::domain::COMPLEX, double,
+                                  std::complex<double>, std::complex<double>)
+// clang-format on
+
+#undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -41,42 +41,66 @@ oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
-#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \
-    /* Buffer API */                                                                         \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* USM API */                                                               \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* Buffer API */                                                            \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* USM API */                                                               \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)   \
+    /* Buffer API */                                                                          \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,  T_REAL>,            \
+    /* USM API */                                                                             \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    /* Buffer API */                                                                          \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    /* USM API */                                                                             \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
 
 ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,

--- a/src/dft/backends/descriptor.cpp
+++ b/src/dft/backends/descriptor.cpp
@@ -28,8 +28,7 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(sycl::queue &queue) {
-    queue_ = queue;
-    pimpl_.reset(detail::create_commit(*this));
+    pimpl_.reset(detail::create_commit(*this, queue));
 }
 template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(sycl::queue &);
 template void descriptor<precision::SINGLE, domain::REAL>::commit(sycl::queue &);

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/dft/types.hpp"
+#include "oneapi/mkl/detail/exceptions.hpp"
 
 #include "oneapi/mkl/dft/descriptor.hpp"
 #include "oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp"
@@ -34,174 +35,76 @@ namespace mkl {
 namespace dft {
 namespace mklcpu {
 
-void compute_backward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<float, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<double, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                sycl::buffer<float, 1> &in_re,
-                                                sycl::buffer<float, 1> &in_im,
-                                                sycl::buffer<float, 1> &out_re,
-                                                sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, sycl::buffer<float, 1> &in_re,
-    sycl::buffer<float, 1> &in_im, sycl::buffer<float, 1> &out_re, sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                sycl::buffer<double, 1> &in_re,
-                                                sycl::buffer<double, 1> &in_im,
-                                                sycl::buffer<double, 1> &out_re,
-                                                sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, sycl::buffer<double, 1> &in_re,
-    sycl::buffer<double, 1> &in_im, sycl::buffer<double, 1> &out_re,
-    sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-sycl::event compute_backward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                           std::complex<float> *inout,
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
                                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                           std::complex<float> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                 float *inout_re, float *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                 double *inout_re, double *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                              std::complex<float> *in, float *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                              std::complex<float> *in, std::complex<float> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                              std::complex<double> *in, double *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                              std::complex<double> *in, std::complex<double> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
-sycl::event compute_backward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_backward_instantiations.cxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -41,7 +41,7 @@ namespace mklcpu {
 template <precision prec, domain dom>
 class commit_derived_impl : public detail::commit_impl {
 public:
-    commit_derived_impl(sycl::queue queue, dft_values config_values)
+    commit_derived_impl(sycl::queue queue, detail::dft_values<prec, dom> config_values)
             : detail::commit_impl(queue),
               status(DFT_NOTSET) {
         if (config_values.rank == 1) {
@@ -102,7 +102,7 @@ private:
         return value_err;
     }
 
-    void set_value(DFTI_DESCRIPTOR_HANDLE& descHandle, dft_values config) {
+    void set_value(DFTI_DESCRIPTOR_HANDLE& descHandle, detail::dft_values<prec, dom> config) {
         set_value_item(descHandle, DFTI_INPUT_STRIDES, config.input_strides.data());
         set_value_item(descHandle, DFTI_OUTPUT_STRIDES, config.output_strides.data());
         set_value_item(descHandle, DFTI_BACKWARD_SCALE, config.bwd_scale);

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -122,14 +122,18 @@ private:
 };
 
 template <precision prec, domain dom>
-detail::commit_impl* create_commit(descriptor<prec, dom>& desc) {
-    return new commit_derived_impl<prec, dom>(desc.get_queue(), desc.get_values());
+detail::commit_impl* create_commit(descriptor<prec, dom>& desc, sycl::queue& sycl_queue) {
+    return new commit_derived_impl<prec, dom>(sycl_queue, desc.get_values());
 }
 
-template detail::commit_impl* create_commit(descriptor<precision::SINGLE, domain::REAL>&);
-template detail::commit_impl* create_commit(descriptor<precision::SINGLE, domain::COMPLEX>&);
-template detail::commit_impl* create_commit(descriptor<precision::DOUBLE, domain::REAL>&);
-template detail::commit_impl* create_commit(descriptor<precision::DOUBLE, domain::COMPLEX>&);
+template detail::commit_impl* create_commit(descriptor<precision::SINGLE, domain::REAL>&,
+                                            sycl::queue&);
+template detail::commit_impl* create_commit(descriptor<precision::SINGLE, domain::COMPLEX>&,
+                                            sycl::queue&);
+template detail::commit_impl* create_commit(descriptor<precision::DOUBLE, domain::REAL>&,
+                                            sycl::queue&);
+template detail::commit_impl* create_commit(descriptor<precision::DOUBLE, domain::COMPLEX>&,
+                                            sycl::queue&);
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/detail/backends.hpp"
 #include "oneapi/mkl/dft/types.hpp"
 #include "oneapi/mkl/dft/descriptor.hpp"
 
@@ -42,7 +43,7 @@ template <precision prec, domain dom>
 class commit_derived_impl : public detail::commit_impl {
 public:
     commit_derived_impl(sycl::queue queue, detail::dft_values<prec, dom> config_values)
-            : detail::commit_impl(queue),
+            : detail::commit_impl(queue, backend::mklcpu),
               status(DFT_NOTSET) {
         if (config_values.rank == 1) {
             status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom),
@@ -62,6 +63,10 @@ public:
         if (status != DFTI_NO_ERROR) {
             throw oneapi::mkl::exception("dft", "commit", "DftiCommitDescriptor failed");
         }
+    }
+
+    virtual void* get_handle() override {
+        return handle;
     }
 
     virtual ~commit_derived_impl() override {

--- a/src/dft/backends/mklcpu/descriptor.cpp
+++ b/src/dft/backends/mklcpu/descriptor.cpp
@@ -28,14 +28,17 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklcpu> selector) {
-    queue_ = selector.get_queue();
-    pimpl_.reset(mklcpu::create_commit(*this));
+    pimpl_.reset(mklcpu::create_commit(*this, selector.get_queue()));
 }
 
-template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(backend_selector<backend::mklcpu>);
-template void descriptor<precision::SINGLE, domain::REAL>::commit(backend_selector<backend::mklcpu>);
-template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(backend_selector<backend::mklcpu>);
-template void descriptor<precision::DOUBLE, domain::REAL>::commit(backend_selector<backend::mklcpu>);
+template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(
+    backend_selector<backend::mklcpu>);
+template void descriptor<precision::SINGLE, domain::REAL>::commit(
+    backend_selector<backend::mklcpu>);
+template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
+    backend_selector<backend::mklcpu>);
+template void descriptor<precision::DOUBLE, domain::REAL>::commit(
+    backend_selector<backend::mklcpu>);
 
 } //namespace dft
 } //namespace mkl

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/dft/types.hpp"
+#include "oneapi/mkl/detail/exceptions.hpp"
 
 #include "oneapi/mkl/dft/descriptor.hpp"
 #include "oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp"
@@ -34,177 +35,74 @@ namespace mkl {
 namespace dft {
 namespace mklcpu {
 
-void compute_forward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                         sycl::buffer<float, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<float>, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                         sycl::buffer<double, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<double>, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-sycl::event compute_forward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          std::complex<float> *inout,
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          std::complex<float> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                float *inout_re, float *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                double *inout_re, double *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             float *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             std::complex<float> *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             double *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             std::complex<double> *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
-sycl::event compute_forward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_forward_instantiations.cxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/mkl_dft_cpu_wrappers.cpp
+++ b/src/dft/backends/mklcpu/mkl_dft_cpu_wrappers.cpp
@@ -21,11 +21,9 @@
 #include "dft/function_table.hpp"
 
 #define WRAPPER_VERSION 1
+#define BACKEND         mklcpu
 
 extern "C" dft_function_table_t mkl_dft_table = {
     WRAPPER_VERSION,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit
+#include "dft/backends/backend_wrappers.cxx"
 };

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -26,8 +26,8 @@ add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
   descriptor.cpp
   commit.cpp
-  forward.cpp
-  backward.cpp
+  # forward.cpp
+  # backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_gpu_wrappers.cpp>
 )
 

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -26,8 +26,8 @@ add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
   descriptor.cpp
   commit.cpp
-  # forward.cpp
-  # backward.cpp
+  forward.cpp
+  backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_gpu_wrappers.cpp>
 )
 

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,182 +24,165 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/exceptions.hpp"
 
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/descriptor_impl.hpp"
+#include "dft/backends/mklgpu/mklgpu_helpers.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace mklgpu {
+namespace detail {
 
-void compute_backward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-
-void compute_backward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
+/// Assumes backend descriptor values match those of the frontend.
+template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
+inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
+    using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
+    using commit_t = dft::detail::commit_impl;
+    auto commit_handle = dft::detail::get_commit(desc);
+    if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {
+        throw mkl::invalid_argument("DFT", "compute_backward",
+                                    "DFT descriptor has not been commited for MKLGPU");
+    }
+    auto mklgpu_desc = reinterpret_cast<mklgpu_desc_t *>(commit_handle->get_handle());
+    int commit_status{ DFTI_UNCOMMITTED };
+    mklgpu_desc->get_value(dft::config_param::COMMIT_STATUS, &commit_status);
+    if (commit_status != DFTI_COMMITTED) {
+        throw mkl::invalid_argument("DFT", "compute_backward",
+                                    "MKLGPU DFT descriptor was not successfully committed.");
+    }
+    return dft::compute_backward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
-void compute_backward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<float, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Throw an mkl::invalid_argument if the runtime param in the descriptor does not match
+/// the expected value.
+template <dft::detail::config_param Param, dft::detail::config_value Expected, typename DescT>
+inline auto expect_config(DescT &desc, const char *message) {
+    dft::detail::config_value actual{ 0 };
+    desc.get_value(Param, &actual);
+    if (actual != Expected) {
+        throw mkl::invalid_argument("DFT", "compute_backward", message);
+    }
 }
-void compute_backward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<double, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+} // namespace detail
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_backward(desc, inout);
 }
 
-void compute_backward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                sycl::buffer<float, 1> &in_re,
-                                                sycl::buffer<float, 1> &in_im,
-                                                sycl::buffer<float, 1> &out_re,
-                                                sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, sycl::buffer<float, 1> &in_re,
-    sycl::buffer<float, 1> &in_im, sycl::buffer<float, 1> &out_re, sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                sycl::buffer<double, 1> &in_re,
-                                                sycl::buffer<double, 1> &in_im,
-                                                sycl::buffer<double, 1> &out_re,
-                                                sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, sycl::buffer<double, 1> &in_re,
-    sycl::buffer<double, 1> &in_im, sycl::buffer<double, 1> &out_re,
-    sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_backward(desc, inout_re, inout_im);
 }
 
-sycl::event compute_backward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                           std::complex<float> *inout,
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_backward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_backward(desc, in, out);
+    }
+}
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_backward(desc, in_re, in_im, out_re, out_im)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
+}
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
                                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                           std::complex<float> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_backward(desc, inout, dependencies);
 }
 
-sycl::event compute_backward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                 float *inout_re, float *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                 double *inout_re, double *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_backward(desc, inout_re, inout_im, dependencies);
 }
 
-sycl::event compute_backward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                              std::complex<float> *in, float *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                              std::complex<float> *in, std::complex<float> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                              std::complex<double> *in, double *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                              std::complex<double> *in, std::complex<double> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_backward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_backward(desc, in, out, dependencies);
+    }
 }
 
-sycl::event compute_backward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_backward(desc, in_re, in_im, out_re, out_im, deps)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
 }
-sycl::event compute_backward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_backward_instantiations.cxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -58,6 +58,9 @@ inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&.
         throw mkl::invalid_argument("DFT", "compute_backward",
                                     "MKLGPU DFT descriptor was not successfully committed.");
     }
+    // The MKLGPU backend's iterface contains fewer function signatures than in this
+    // open-source library. Consequently, it is not required to forward template arguments
+    // to resolve to the correct function.
     return dft::compute_backward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
@@ -87,12 +90,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_typ
 template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                                     sycl::buffer<data_type, 1> &inout_im) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_backward(desc, inout_re, inout_im);
+    throw mkl::unimplemented("DFT", "compute_backward",
+                             "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform
@@ -142,12 +141,8 @@ template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
                                            data_type *inout_im,
                                            const std::vector<sycl::event> &dependencies) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_backward(desc, inout_re, inout_im, dependencies);
+    throw mkl::unimplemented("DFT", "compute_backward",
+                             "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/detail/backends.hpp"
 
 #include "oneapi/mkl/dft/detail/commit_impl.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
@@ -59,7 +60,7 @@ private:
 
 public:
     commit_derived_impl(sycl::queue queue, dft::detail::dft_values<prec, dom> config_values)
-            : oneapi::mkl::dft::detail::commit_impl(queue),
+            : oneapi::mkl::dft::detail::commit_impl(queue, backend::mklgpu),
               handle(config_values.dimensions) {
         set_value(handle, config_values);
         // MKLGPU does not throw an informative exception for the following:
@@ -76,6 +77,10 @@ public:
             // Catching the real MKL exception causes headaches with naming.
             throw mkl::exception("DFT", "commit", mkl_exception.what());
         }
+    }
+
+    virtual void* get_handle() override {
+        return &handle;
     }
 
     virtual ~commit_derived_impl() override {}

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -129,18 +129,23 @@ private:
 } // namespace detail
 
 template <dft::detail::precision prec, dft::detail::domain dom>
-dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc) {
-    return new detail::commit_derived_impl<prec, dom>(desc.get_queue(), desc.get_values());
+dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc,
+                                        sycl::queue& sycl_queue) {
+    return new detail::commit_derived_impl<prec, dom>(sycl_queue, desc.get_values());
 }
 
 template dft::detail::commit_impl* create_commit(
-    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::REAL>&);
+    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::REAL>&,
+    sycl::queue&);
 template dft::detail::commit_impl* create_commit(
-    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>&);
+    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>&,
+    sycl::queue&);
 template dft::detail::commit_impl* create_commit(
-    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>&);
+    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>&,
+    sycl::queue&);
 template dft::detail::commit_impl* create_commit(
-    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>&);
+    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>&,
+    sycl::queue&);
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -24,26 +24,108 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/exceptions.hpp"
 
+#include "oneapi/mkl/dft/detail/commit_impl.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/descriptor_impl.hpp"
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
+
+#include "dft/backends/mklgpu/mklgpu_helpers.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
+
+/**
+Note that in this file, the Intel MKL-GPU library's interface mirrors the interface
+of this OneMKL library. Consequently, the types under dft::TYPE are closed-source MKL types, 
+and types under dft::detail::TYPE are from this library.
+**/
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace mklgpu {
+namespace detail {
 
-void commit_f(descriptor<precision::SINGLE, domain::REAL> &desc, sycl::queue &queue) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Commit impl class specialization for MKLGPU.
+template <dft::detail::precision prec, dft::detail::domain dom>
+class commit_derived_impl : public dft::detail::commit_impl {
+private:
+    // Equivalent MKLGPU precision and domain from OneMKL's precision / domain.
+    static constexpr dft::precision mklgpu_prec = to_mklgpu(prec);
+    static constexpr dft::domain mklgpu_dom = to_mklgpu(dom);
+    using mklgpu_descriptor_t = dft::descriptor<mklgpu_prec, mklgpu_dom>;
+
+public:
+    commit_derived_impl(sycl::queue queue, dft::detail::dft_values config_values)
+            : oneapi::mkl::dft::detail::commit_impl(queue),
+              handle(config_values.dimensions) {
+        set_value(handle, config_values);
+        // MKLGPU does not throw an informative exception for the following:
+        if constexpr (prec == dft::detail::precision::DOUBLE) {
+            if (!queue.get_device().has(sycl::aspect::fp64)) {
+                throw mkl::exception("DFT", "commit", "Device does not support double precision.");
+            }
+        }
+
+        try {
+            handle.commit(queue);
+        }
+        catch (const std::exception& mkl_exception) {
+            // Catching the real MKL exception causes headaches with naming.
+            throw mkl::exception("DFT", "commit", mkl_exception.what());
+        }
+    }
+
+    virtual ~commit_derived_impl() override {}
+
+private:
+    // The native MKLGPU class.
+    mklgpu_descriptor_t handle;
+
+    void set_value(mklgpu_descriptor_t& desc, dft::detail::dft_values config) {
+        using onemkl_param = dft::detail::config_param;
+        using backend_param = dft::config_param;
+
+        // The following are read-only:
+        // Dimension, forward domain, precision, commit status.
+        // Lengths are supplied at descriptor construction time.
+        desc.set_value(backend_param::FORWARD_SCALE, config.fwd_scale);
+        desc.set_value(backend_param::BACKWARD_SCALE, config.bwd_scale);
+        desc.set_value(backend_param::NUMBER_OF_TRANSFORMS, config.number_of_transforms);
+        desc.set_value(backend_param::COMPLEX_STORAGE,
+                       to_mklgpu<onemkl_param::COMPLEX_STORAGE>(config.complex_storage));
+        // Conjugate even storage only supports COMPLEX_COMPLEX. to_mklgpu will throw on invalid config.
+        (void)to_mklgpu<onemkl_param::CONJUGATE_EVEN_STORAGE>(config.conj_even_storage);
+        desc.set_value(backend_param::PLACEMENT,
+                       to_mklgpu<onemkl_param::PLACEMENT>(config.placement));
+        desc.set_value(backend_param::INPUT_STRIDES, config.input_strides.data());
+        desc.set_value(backend_param::OUTPUT_STRIDES, config.output_strides.data());
+        desc.set_value(backend_param::FWD_DISTANCE, config.fwd_dist);
+        desc.set_value(backend_param::BWD_DISTANCE, config.bwd_dist);
+        // Leave backend_param::REAL_STORAGE as default value (exists as config param, but no value in dft_values)
+        // Leave backend_param::WORKSPACE as default value.
+        // Leave backend_param::ORDERING as default value.
+        // Leave backend_param::TRANSPOSE as false (default value).
+        // Leave backend_param::PACKED_FORMAT as only available value: CCE_FORMAT.
+    }
+};
+} // namespace detail
+
+template <dft::detail::precision prec, dft::detail::domain dom>
+dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc) {
+    return new detail::commit_derived_impl<prec, dom>(desc.get_queue(), desc.get_values());
 }
-void commit_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc, sycl::queue &queue) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void commit_d(descriptor<precision::DOUBLE, domain::REAL> &desc, sycl::queue &queue) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void commit_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc, sycl::queue &queue) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
+
+template dft::detail::commit_impl* create_commit(
+    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::REAL>&);
+template dft::detail::commit_impl* create_commit(
+    dft::detail::descriptor<dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX>&);
+template dft::detail::commit_impl* create_commit(
+    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::REAL>&);
+template dft::detail::commit_impl* create_commit(
+    dft::detail::descriptor<dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX>&);
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/descriptor.cpp
+++ b/src/dft/backends/mklgpu/descriptor.cpp
@@ -28,14 +28,17 @@ namespace dft {
 
 template <precision prec, domain dom>
 void descriptor<prec, dom>::commit(backend_selector<backend::mklgpu> selector) {
-    queue_ = selector.get_queue();
-    pimpl_.reset(mklgpu::create_commit(*this));
+    pimpl_.reset(mklgpu::create_commit(*this, selector.get_queue()));
 }
 
-template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(backend_selector<backend::mklgpu>);
-template void descriptor<precision::SINGLE, domain::REAL>::commit(backend_selector<backend::mklgpu>);
-template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(backend_selector<backend::mklgpu>);
-template void descriptor<precision::DOUBLE, domain::REAL>::commit(backend_selector<backend::mklgpu>);
+template void descriptor<precision::SINGLE, domain::COMPLEX>::commit(
+    backend_selector<backend::mklgpu>);
+template void descriptor<precision::SINGLE, domain::REAL>::commit(
+    backend_selector<backend::mklgpu>);
+template void descriptor<precision::DOUBLE, domain::COMPLEX>::commit(
+    backend_selector<backend::mklgpu>);
+template void descriptor<precision::DOUBLE, domain::REAL>::commit(
+    backend_selector<backend::mklgpu>);
 
 } //namespace dft
 } //namespace mkl

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -65,6 +65,9 @@ inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&..
         throw mkl::invalid_argument("DFT", "compute_forward",
                                     "MKLGPU DFT descriptor was not successfully committed.");
     }
+    // The MKLGPU backend's iterface contains fewer function signatures than in this
+    // open-source library. Consequently, it is not required to forward template arguments
+    // to resolve to the correct function.
     return dft::compute_forward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
@@ -94,12 +97,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type
 template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                                    sycl::buffer<data_type, 1> &inout_im) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_forward(desc, inout_re, inout_im);
+    throw mkl::unimplemented("DFT", "compute_forward",
+                             "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform
@@ -149,12 +148,8 @@ template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
                                           data_type *inout_im,
                                           const std::vector<sycl::event> &dependencies) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_forward(desc, inout_re, inout_im, dependencies);
+    throw mkl::unimplemented("DFT", "compute_forward",
+                             "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#include <type_traits>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
@@ -24,185 +25,172 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/exceptions.hpp"
 
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/descriptor_impl.hpp"
+
+#include "dft/backends/mklgpu/mklgpu_helpers.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
+
+/**
+Note that in this file, the Intel MKL-GPU library's interface mirrors the interface
+of this OneMKL library. Consequently, the types under dft::TYPE are closed-source MKL types, 
+and types under dft::detail::TYPE are from this library.
+**/
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace mklgpu {
-
-void compute_forward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-
-void compute_forward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+namespace detail {
+/// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
+/// Assumes backend descriptor values match those of the frontend.
+template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
+inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
+    using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
+    using commit_t = dft::detail::commit_impl;
+    auto commit_handle = dft::detail::get_commit(desc);
+    if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {
+        throw mkl::invalid_argument("DFT", "compute_forward",
+                                    "DFT descriptor has not been commited for MKLGPU");
+    }
+    auto mklgpu_desc = reinterpret_cast<mklgpu_desc_t *>(commit_handle->get_handle());
+    int commit_status{ DFTI_UNCOMMITTED };
+    mklgpu_desc->get_value(dft::config_param::COMMIT_STATUS, &commit_status);
+    if (commit_status != DFTI_COMMITTED) {
+        throw mkl::invalid_argument("DFT", "compute_forward",
+                                    "MKLGPU DFT descriptor was not successfully committed.");
+    }
+    return dft::compute_forward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
-void compute_forward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                         sycl::buffer<float, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Throw an mkl::invalid_argument if the runtime param in the descriptor does not match
+/// the expected value.
+template <dft::detail::config_param Param, dft::detail::config_value Expected, typename DescT>
+inline auto expect_config(DescT &desc, const char *message) {
+    dft::detail::config_value actual{ 0 };
+    desc.get_value(Param, &actual);
+    if (actual != Expected) {
+        throw mkl::invalid_argument("DFT", "compute_forward", message);
+    }
 }
-void compute_forward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<float>, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                         sycl::buffer<double, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<double>, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+} // namespace detail
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_forward(desc, inout);
 }
 
-void compute_forward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_forward(desc, inout_re, inout_im);
 }
 
-sycl::event compute_forward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          std::complex<float> *inout,
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_forward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_forward(desc, in, out);
+    }
+}
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
+}
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          std::complex<float> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_forward(desc, inout, dependencies);
 }
 
-sycl::event compute_forward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                float *inout_re, float *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                double *inout_re, double *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_forward(desc, inout_re, inout_im, dependencies);
 }
 
-sycl::event compute_forward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             float *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             std::complex<float> *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             double *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             std::complex<double> *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_forward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        // Check: inplace, complex storage
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_forward(desc, in, out, dependencies);
+    }
 }
 
-sycl::event compute_forward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im, deps)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
 }
-sycl::event compute_forward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_forward_instantiations.cxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
+++ b/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
@@ -22,29 +22,8 @@
 
 #define WRAPPER_VERSION 1
 
-extern "C" dft_function_table_t mkl_dft_table = {
-    WRAPPER_VERSION,
-#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT)                                    \
-    oneapi::mkl::dft::mklgpu::commit_##EXT,                                       \
-        oneapi::mkl::dft::mklgpu::compute_forward_buffer_inplace_##EXT,           \
-        oneapi::mkl::dft::mklgpu::compute_forward_buffer_inplace_split_##EXT,     \
-        oneapi::mkl::dft::mklgpu::compute_forward_buffer_outofplace_##EXT,        \
-        oneapi::mkl::dft::mklgpu::compute_forward_buffer_outofplace_split_##EXT,  \
-        oneapi::mkl::dft::mklgpu::compute_forward_usm_inplace_##EXT,              \
-        oneapi::mkl::dft::mklgpu::compute_forward_usm_inplace_split_##EXT,        \
-        oneapi::mkl::dft::mklgpu::compute_forward_usm_outofplace_##EXT,           \
-        oneapi::mkl::dft::mklgpu::compute_forward_usm_outofplace_split_##EXT,     \
-        oneapi::mkl::dft::mklgpu::compute_backward_buffer_inplace_##EXT,          \
-        oneapi::mkl::dft::mklgpu::compute_backward_buffer_inplace_split_##EXT,    \
-        oneapi::mkl::dft::mklgpu::compute_backward_buffer_outofplace_##EXT,       \
-        oneapi::mkl::dft::mklgpu::compute_backward_buffer_outofplace_split_##EXT, \
-        oneapi::mkl::dft::mklgpu::compute_backward_usm_inplace_##EXT,             \
-        oneapi::mkl::dft::mklgpu::compute_backward_usm_inplace_split_##EXT,       \
-        oneapi::mkl::dft::mklgpu::compute_backward_usm_outofplace_##EXT,          \
-        oneapi::mkl::dft::mklgpu::compute_backward_usm_outofplace_split_##EXT
-
-    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(f), ONEAPI_MKL_DFT_BACKEND_SIGNATURES(c),
-    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(d), ONEAPI_MKL_DFT_BACKEND_SIGNATURES(z)
-
-#undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES
-};
+extern "C" dft_function_table_t mkl_dft_table = { WRAPPER_VERSION,
+                                                  oneapi::mkl::dft::mklgpu::create_commit,
+                                                  oneapi::mkl::dft::mklgpu::create_commit,
+                                                  oneapi::mkl::dft::mklgpu::create_commit,
+                                                  oneapi::mkl::dft::mklgpu::create_commit };

--- a/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
+++ b/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
@@ -21,9 +21,9 @@
 #include "dft/function_table.hpp"
 
 #define WRAPPER_VERSION 1
+#define BACKEND         mklgpu
 
-extern "C" dft_function_table_t mkl_dft_table = { WRAPPER_VERSION,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit };
+extern "C" dft_function_table_t mkl_dft_table = {
+    WRAPPER_VERSION,
+#include "dft/backends/backend_wrappers.cxx"
+};

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -76,7 +76,8 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
         case iparam::COMMIT_STATUS: return oparam::COMMIT_STATUS;
         default:
-            mkl::invalid_argument("dft", "MKLGPU descriptor set_value()", "Invalid config param.");
+            throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                        "Invalid config param.");
             return static_cast<oparam>(0);
     }
 }
@@ -94,12 +95,9 @@ inline constexpr int to_mklgpu<dft::detail::config_param::COMPLEX_STORAGE>(
     if (value == dft::detail::config_value::COMPLEX_COMPLEX) {
         return DFTI_COMPLEX_COMPLEX;
     }
-    else if (value == dft::detail::config_value::REAL_REAL) {
-        return DFTI_COMPLEX_REAL;
-    }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for complex storage.");
+        throw mkl::unimplemented("dft", "MKLGPU descriptor set_value()",
+                                 "MKLGPU only supports complex-complex for complex storage.");
         return 0;
     }
 }
@@ -111,8 +109,8 @@ inline constexpr int to_mklgpu<dft::detail::config_param::CONJUGATE_EVEN_STORAGE
         return DFTI_COMPLEX_COMPLEX;
     }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for conjugate even storage.");
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for conjugate even storage.");
         return 0;
     }
 }
@@ -127,12 +125,24 @@ inline constexpr int to_mklgpu<dft::detail::config_param::PLACEMENT>(
         return DFTI_NOT_INPLACE;
     }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for inplace.");
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for inplace.");
         return 0;
     }
 }
 
+template <>
+inline constexpr int to_mklgpu<dft::detail::config_param::PACKED_FORMAT>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::CCE_FORMAT) {
+        return DFTI_CCE_FORMAT;
+    }
+    else {
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for packed format.");
+        return 0;
+    }
+}
 } // namespace detail
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _ONEMKL_DFT_SRC_MKLGPU_HELPERS_HPP_
+#define _ONEMKL_DFT_SRC_MKLGPU_HELPERS_HPP_
+
+#include "oneapi/mkl/detail/exceptions.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace dft {
+namespace mklgpu {
+namespace detail {
+
+/// Convert domain to equivalent backend native value.
+inline constexpr dft::domain to_mklgpu(dft::detail::domain dom) {
+    if (dom == dft::detail::domain::REAL) {
+        return dft::domain::REAL;
+    }
+    else {
+        return dft::domain::COMPLEX;
+    }
+}
+
+/// Convert precision to equivalent backend native value.
+inline constexpr dft::precision to_mklgpu(dft::detail::precision dom) {
+    if (dom == dft::detail::precision::SINGLE) {
+        return dft::precision::SINGLE;
+    }
+    else {
+        return dft::precision::DOUBLE;
+    }
+}
+
+/// Convert a config_param to equivalent backend native value.
+inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
+    using iparam = dft::detail::config_param;
+    using oparam = dft::config_param;
+    switch (param) {
+        case iparam::FORWARD_DOMAIN: return oparam::FORWARD_DOMAIN;
+        case iparam::DIMENSION: return oparam::DIMENSION;
+        case iparam::LENGTHS: return oparam::LENGTHS;
+        case iparam::PRECISION: return oparam::PRECISION;
+        case iparam::FORWARD_SCALE: return oparam::FORWARD_SCALE;
+        case iparam::NUMBER_OF_TRANSFORMS: return oparam::NUMBER_OF_TRANSFORMS;
+        case iparam::COMPLEX_STORAGE: return oparam::COMPLEX_STORAGE;
+        case iparam::REAL_STORAGE: return oparam::REAL_STORAGE;
+        case iparam::CONJUGATE_EVEN_STORAGE: return oparam::CONJUGATE_EVEN_STORAGE;
+        case iparam::INPUT_STRIDES: return oparam::INPUT_STRIDES;
+        case iparam::OUTPUT_STRIDES: return oparam::OUTPUT_STRIDES;
+        case iparam::FWD_DISTANCE: return oparam::FWD_DISTANCE;
+        case iparam::BWD_DISTANCE: return oparam::BWD_DISTANCE;
+        case iparam::WORKSPACE: return oparam::WORKSPACE;
+        case iparam::ORDERING: return oparam::ORDERING;
+        case iparam::TRANSPOSE: return oparam::TRANSPOSE;
+        case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
+        case iparam::COMMIT_STATUS: return oparam::COMMIT_STATUS;
+        default:
+            mkl::invalid_argument("dft", "MKLGPU descriptor set_value()", "Invalid config param.");
+            return static_cast<oparam>(0);
+    }
+}
+
+/** Convert a config_value to the backend's native value. Throw on invalid input.
+ * @tparam Param The config param the value is for.
+ * @param value The config value to convert.
+**/
+template <dft::detail::config_param Param>
+inline constexpr int to_mklgpu(dft::detail::config_value value);
+
+template <>
+inline constexpr int to_mklgpu<dft::detail::config_param::COMPLEX_STORAGE>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::COMPLEX_COMPLEX) {
+        return DFTI_COMPLEX_COMPLEX;
+    }
+    else if (value == dft::detail::config_value::REAL_REAL) {
+        return DFTI_COMPLEX_REAL;
+    }
+    else {
+        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                              "Invalid config value for complex storage.");
+        return 0;
+    }
+}
+
+template <>
+inline constexpr int to_mklgpu<dft::detail::config_param::CONJUGATE_EVEN_STORAGE>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::COMPLEX_COMPLEX) {
+        return DFTI_COMPLEX_COMPLEX;
+    }
+    else {
+        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                              "Invalid config value for conjugate even storage.");
+        return 0;
+    }
+}
+
+template <>
+inline constexpr int to_mklgpu<dft::detail::config_param::PLACEMENT>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::INPLACE) {
+        return DFTI_INPLACE;
+    }
+    else if (value == dft::detail::config_value::NOT_INPLACE) {
+        return DFTI_NOT_INPLACE;
+    }
+    else {
+        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                              "Invalid config value for inplace.");
+        return 0;
+    }
+}
+
+} // namespace detail
+} // namespace mklgpu
+} // namespace dft
+} // namespace mkl
+} // namespace oneapi
+
+#endif // _ONEMKL_DFT_SRC_MKLGPU_HELPERS_HPP_

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -17,60 +17,126 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#include "oneapi/mkl/detail/exceptions.hpp"
 #include "oneapi/mkl/dft/descriptor.hpp"
+
+#include "dft/descriptor_config_helper.hpp"
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace detail {
 
+// Compute the default strides. Modifies real_strides and complex_strides arguments.
+void compute_default_strides(const std::vector<std::int64_t>& dimensions, int rank,
+                             std::vector<std::int64_t>& input_strides,
+                             std::vector<std::int64_t>& output_strides) {
+    std::vector<std::int64_t> strides(rank + 1, 1);
+    for (int i = rank - 1; i > 0; --i) {
+        strides[i] = strides[i + 1] * dimensions[i];
+    }
+    strides[0] = 0;
+    output_strides = strides;
+    input_strides = std::move(strides);
+}
+
 template <precision prec, domain dom>
 void descriptor<prec, dom>::set_value(config_param param, ...) {
-    int err = 0;
+    if (pimpl_) {
+        throw mkl::invalid_argument("DFT", "set_value",
+                                    "Cannot set value on committed descriptor.");
+    }
     va_list vl;
     va_start(vl, param);
     switch (param) {
-        case config_param::INPUT_STRIDES: [[fallthrough]];
-        case config_param::OUTPUT_STRIDES: {
-            int64_t *strides = va_arg(vl, int64_t *);
-            if (strides == nullptr)
-                break;
-            if (param == config_param::INPUT_STRIDES)
-                std::copy(strides, strides + rank_ + 1, std::back_inserter(values_.input_strides));
-            if (param == config_param::OUTPUT_STRIDES)
-                std::copy(strides, strides + rank_ + 1, std::back_inserter(values_.output_strides));
+        case config_param::FORWARD_DOMAIN:
+            throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
+            break;
+        case config_param::DIMENSION:
+            throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
+            break;
+        case config_param::LENGTHS: {
+            if (values_.rank == 1) {
+                std::int64_t length = va_arg(vl, std::int64_t);
+                detail::set_value<config_param::LENGTHS>(values_, &length);
+            }
+            else {
+                detail::set_value<config_param::LENGTHS>(values_, va_arg(vl, std::int64_t*));
+            }
             break;
         }
-        case config_param::FORWARD_SCALE: values_.fwd_scale = va_arg(vl, double); break;
-        case config_param::BACKWARD_SCALE: values_.bwd_scale = va_arg(vl, double); break;
-        case config_param::NUMBER_OF_TRANSFORMS:
-            values_.number_of_transforms = va_arg(vl, int64_t);
+        case config_param::PRECISION:
+            throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
             break;
-        case config_param::FWD_DISTANCE: values_.fwd_dist = va_arg(vl, int64_t); break;
-        case config_param::BWD_DISTANCE: values_.bwd_dist = va_arg(vl, int64_t); break;
-        case config_param::PLACEMENT: values_.placement = va_arg(vl, config_value); break;
+        case config_param::INPUT_STRIDES:
+            detail::set_value<config_param::INPUT_STRIDES>(values_, va_arg(vl, std::int64_t*));
+            break;
+        case config_param::OUTPUT_STRIDES: {
+            detail::set_value<config_param::OUTPUT_STRIDES>(values_, va_arg(vl, std::int64_t*));
+            break;
+        }
+        // VA arg promotes float args to double, so the following is always double:
+        case config_param::FORWARD_SCALE:
+            detail::set_value<config_param::FORWARD_SCALE>(values_, va_arg(vl, double));
+            break;
+        case config_param::BACKWARD_SCALE:
+            detail::set_value<config_param::BACKWARD_SCALE>(values_, va_arg(vl, double));
+            break;
+        case config_param::NUMBER_OF_TRANSFORMS:
+            detail::set_value<config_param::NUMBER_OF_TRANSFORMS>(values_,
+                                                                  va_arg(vl, std::int64_t));
+            break;
+        case config_param::FWD_DISTANCE:
+            detail::set_value<config_param::FWD_DISTANCE>(values_, va_arg(vl, std::int64_t));
+            break;
+        case config_param::BWD_DISTANCE:
+            detail::set_value<config_param::BWD_DISTANCE>(values_, va_arg(vl, std::int64_t));
+            break;
+        case config_param::PLACEMENT:
+            detail::set_value<config_param::PLACEMENT>(values_, va_arg(vl, config_value));
+            break;
         case config_param::COMPLEX_STORAGE:
-            values_.complex_storage = va_arg(vl, config_value);
+            detail::set_value<config_param::COMPLEX_STORAGE>(values_, va_arg(vl, config_value));
+            break;
+        case config_param::REAL_STORAGE:
+            detail::set_value<config_param::REAL_STORAGE>(values_, va_arg(vl, config_value));
             break;
         case config_param::CONJUGATE_EVEN_STORAGE:
-            values_.conj_even_storage = va_arg(vl, config_value);
+            detail::set_value<config_param::CONJUGATE_EVEN_STORAGE>(values_,
+                                                                    va_arg(vl, config_value));
             break;
-        default: err = 1;
+        case config_param::ORDERING:
+            detail::set_value<config_param::ORDERING>(values_, va_arg(vl, config_value));
+            break;
+        case config_param::TRANSPOSE:
+            detail::set_value<config_param::TRANSPOSE>(values_, va_arg(vl, int));
+            break;
+        case config_param::PACKED_FORMAT:
+            detail::set_value<config_param::PACKED_FORMAT>(values_, va_arg(vl, config_value));
+            break;
+        case config_param::COMMIT_STATUS:
+            throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
+            break;
+        default: throw mkl::invalid_argument("DFT", "set_value", "Invalid config_param argument.");
     }
     va_end(vl);
 }
+
 template <precision prec, domain dom>
 descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
         : dimensions_(std::move(dimensions)),
           rank_(dimensions.size()) {
-    // Compute default strides.
-    std::vector<std::int64_t> defaultStrides(rank_, 1);
-    for (int i = rank_ - 1; i < 0; --i) {
-        defaultStrides[i] = defaultStrides[i - 1] * dimensions_[i];
+    if (dimensions_.size() == 0) {
+        throw mkl::invalid_argument("DFT", "descriptor", "Cannot have 0 dimensional DFT.");
     }
-    defaultStrides[0] = 0;
-    values_.input_strides = defaultStrides;
-    values_.output_strides = std::move(defaultStrides);
+    for (const auto& dim : dimensions) {
+        if (dim <= 0) {
+            throw mkl::invalid_argument("DFT", "descriptor",
+                                        "Invalid dimension value (negative or 0).");
+        }
+    }
+    // Assume forward transform.
+    compute_default_strides(dimensions_, rank_, values_.input_strides, values_.output_strides);
     values_.bwd_scale = 1.0;
     values_.fwd_scale = 1.0;
     values_.number_of_transforms = 1;
@@ -78,11 +144,14 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
     values_.bwd_dist = 1;
     values_.placement = config_value::INPLACE;
     values_.complex_storage = config_value::COMPLEX_COMPLEX;
+    values_.real_storage = config_value::REAL_REAL;
     values_.conj_even_storage = config_value::COMPLEX_COMPLEX;
+    values_.workspace = config_value::ALLOW;
+    values_.ordering = config_value::ORDERED;
+    values_.transpose = false;
+    values_.packed_format = config_value::CCE_FORMAT;
     values_.dimensions = dimensions_;
     values_.rank = rank_;
-    values_.domain = dom;
-    values_.precision = prec;
 }
 
 template <precision prec, domain dom>
@@ -95,10 +164,58 @@ descriptor<prec, dom>::~descriptor() {}
 template <precision prec, domain dom>
 void descriptor<prec, dom>::get_value(config_param param, ...) {
     int err = 0;
+    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
     va_list vl;
     va_start(vl, param);
+    if (va_arg(vl, void*) == nullptr) {
+        throw mkl::invalid_argument("DFT", "get_value", "config_param is nullptr.");
+    }
+    va_end(vl);
+    va_start(vl, param);
     switch (param) {
-        default: break;
+        case config_param::FORWARD_DOMAIN: *va_arg(vl, dft::domain*) = dom; break;
+        case config_param::DIMENSION: *va_arg(vl, std::int64_t*) = values_.rank; break;
+        case config_param::LENGTHS:
+            std::copy(values_.dimensions.begin(), values_.dimensions.end(),
+                      va_arg(vl, std::int64_t*));
+            break;
+        case config_param::PRECISION: *va_arg(vl, dft::precision*) = prec; break;
+        case config_param::FORWARD_SCALE:
+            *va_arg(vl, real_t*) = static_cast<real_t>(values_.fwd_scale);
+            break;
+        case config_param::BACKWARD_SCALE:
+            *va_arg(vl, real_t*) = static_cast<real_t>(values_.bwd_scale);
+            break;
+        case config_param::NUMBER_OF_TRANSFORMS:
+            *va_arg(vl, std::int64_t*) = values_.number_of_transforms;
+            break;
+        case config_param::COMPLEX_STORAGE:
+            *va_arg(vl, config_value*) = values_.complex_storage;
+            break;
+        case config_param::REAL_STORAGE: *va_arg(vl, config_value*) = values_.real_storage; break;
+        case config_param::CONJUGATE_EVEN_STORAGE:
+            *va_arg(vl, config_value*) = values_.conj_even_storage;
+            break;
+        case config_param::PLACEMENT: *va_arg(vl, config_value*) = values_.placement; break;
+        case config_param::INPUT_STRIDES:
+            std::copy(values_.input_strides.begin(), values_.input_strides.end(),
+                      va_arg(vl, std::int64_t*));
+            break;
+        case config_param::OUTPUT_STRIDES:
+            std::copy(values_.output_strides.begin(), values_.output_strides.end(),
+                      va_arg(vl, std::int64_t*));
+            break;
+        case config_param::FWD_DISTANCE: *va_arg(vl, std::int64_t*) = values_.fwd_dist; break;
+        case config_param::BWD_DISTANCE: *va_arg(vl, std::int64_t*) = values_.bwd_dist; break;
+        case config_param::WORKSPACE: *va_arg(vl, config_value*) = values_.workspace; break;
+        case config_param::ORDERING: *va_arg(vl, config_value*) = values_.ordering; break;
+        case config_param::TRANSPOSE: *va_arg(vl, int*) = values_.transpose; break;
+        case config_param::PACKED_FORMAT: *va_arg(vl, config_value*) = values_.packed_format; break;
+        case config_param::COMMIT_STATUS:
+            *va_arg(vl, config_value*) =
+                pimpl_ ? config_value::COMMITTED : config_value::UNCOMMITTED;
+            break;
+        default: throw mkl::invalid_argument("DFT", "get_value", "Invalid config_param argument.");
     }
     va_end(vl);
 }

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -28,9 +28,10 @@ namespace dft {
 namespace detail {
 
 // Compute the default strides. Modifies real_strides and complex_strides arguments.
-void compute_default_strides(const std::vector<std::int64_t>& dimensions, int rank,
+void compute_default_strides(const std::vector<std::int64_t>& dimensions,
                              std::vector<std::int64_t>& input_strides,
                              std::vector<std::int64_t>& output_strides) {
+    int rank = dimensions.size();
     std::vector<std::int64_t> strides(rank + 1, 1);
     for (int i = rank - 1; i > 0; --i) {
         strides[i] = strides[i + 1] * dimensions[i];
@@ -123,10 +124,8 @@ void descriptor<prec, dom>::set_value(config_param param, ...) {
 }
 
 template <precision prec, domain dom>
-descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
-        : dimensions_(std::move(dimensions)),
-          rank_(dimensions.size()) {
-    if (dimensions_.size() == 0) {
+descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions) {
+    if (dimensions.size() == 0) {
         throw mkl::invalid_argument("DFT", "descriptor", "Cannot have 0 dimensional DFT.");
     }
     for (const auto& dim : dimensions) {
@@ -136,7 +135,7 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
         }
     }
     // Assume forward transform.
-    compute_default_strides(dimensions_, rank_, values_.input_strides, values_.output_strides);
+    compute_default_strides(dimensions, values_.input_strides, values_.output_strides);
     values_.bwd_scale = 1.0;
     values_.fwd_scale = 1.0;
     values_.number_of_transforms = 1;
@@ -150,8 +149,8 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
     values_.ordering = config_value::ORDERED;
     values_.transpose = false;
     values_.packed_format = config_value::CCE_FORMAT;
-    values_.dimensions = dimensions_;
-    values_.rank = rank_;
+    values_.dimensions = std::move(dimensions);
+    values_.rank = values_.dimensions.size();
 }
 
 template <precision prec, domain dom>

--- a/src/dft/descriptor_config_helper.hpp
+++ b/src/dft/descriptor_config_helper.hpp
@@ -1,0 +1,319 @@
+/*******************************************************************************
+* Copyright Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_
+#define _ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "oneapi/mkl/dft/descriptor.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace dft {
+namespace detail {
+
+/// Helper to get real type from precision.
+template <precision Prec>
+struct real_helper;
+
+template <>
+struct real_helper<precision::SINGLE> {
+    using type = float;
+};
+
+template <>
+struct real_helper<precision::DOUBLE> {
+    using type = double;
+};
+
+template <precision Prec>
+using real_helper_t = typename real_helper<Prec>::type;
+
+/** Helper to get the argument type for a config param.
+ * @tparam RealT The real type for the DFT.
+ * @tparam Param The config param to get the arg for.
+**/
+template <typename RealT, config_param Param>
+struct param_type_helper;
+
+template <typename RealT, config_param Param>
+using param_type_helper_t = typename param_type_helper<RealT, Param>::type;
+
+#define PARAM_TYPE_HELPER(param, param_type) \
+    template <typename RealT>                \
+    struct param_type_helper<RealT, param> { \
+        using type = param_type;             \
+    };
+PARAM_TYPE_HELPER(config_param::FORWARD_DOMAIN, domain)
+PARAM_TYPE_HELPER(config_param::DIMENSION, std::int64_t)
+PARAM_TYPE_HELPER(config_param::LENGTHS, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::PRECISION, precision)
+PARAM_TYPE_HELPER(config_param::FORWARD_SCALE, RealT)
+PARAM_TYPE_HELPER(config_param::BACKWARD_SCALE, RealT)
+PARAM_TYPE_HELPER(config_param::NUMBER_OF_TRANSFORMS, std::int64_t)
+PARAM_TYPE_HELPER(config_param::COMPLEX_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::REAL_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::CONJUGATE_EVEN_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::PLACEMENT, config_value)
+PARAM_TYPE_HELPER(config_param::INPUT_STRIDES, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::OUTPUT_STRIDES, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::FWD_DISTANCE, std::int64_t)
+PARAM_TYPE_HELPER(config_param::BWD_DISTANCE, std::int64_t)
+PARAM_TYPE_HELPER(config_param::WORKSPACE, config_value)
+PARAM_TYPE_HELPER(config_param::ORDERING, config_value)
+PARAM_TYPE_HELPER(config_param::TRANSPOSE, bool)
+PARAM_TYPE_HELPER(config_param::PACKED_FORMAT, config_value)
+PARAM_TYPE_HELPER(config_param::COMMIT_STATUS, config_value)
+#undef PARAM_TYPE_HELPER
+
+/** Helper struct to set value in dft_values, throwing on invalid args.
+ * @tparam Param The config param to set.
+ * @tparam prec The precision of the DFT.
+ * @tparam dom The domain of the DFT.
+**/
+template <config_param Param, precision prec, domain dom>
+struct set_value_helper;
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::LENGTHS, prec, dom> {
+    static void set_val(dft_values<prec, dom>& vals,
+                        param_type_helper_t<real_helper_t<prec>, config_param::LENGTHS>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        for (int i{ 0 }; i < rank; ++i) {
+            if (set_val[i] <= 0) {
+                throw mkl::invalid_argument("DFT", "set_value",
+                                            "Invalid length value (negative or 0).");
+            }
+        }
+        std::copy(set_val, set_val + rank, vals.dimensions.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PRECISION, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PRECISION>& set_val) {
+        throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::FORWARD_SCALE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::FORWARD_SCALE>& set_val) {
+        vals.fwd_scale = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::BACKWARD_SCALE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::BACKWARD_SCALE>& set_val) {
+        vals.bwd_scale = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::NUMBER_OF_TRANSFORMS, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::NUMBER_OF_TRANSFORMS>& set_val) {
+        if (set_val <= 0) {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Number of transforms must be positive.");
+        }
+        vals.number_of_transforms = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::COMPLEX_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::COMPLEX_STORAGE>& set_val) {
+        if (set_val == config_value::COMPLEX_COMPLEX || set_val == config_value::REAL_REAL) {
+            vals.complex_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Complex storage must be complex_complex or real_real.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::REAL_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::REAL_STORAGE>& set_val) {
+        if (set_val == config_value::REAL_REAL) {
+            vals.real_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Real storage must be real_real.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::CONJUGATE_EVEN_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::CONJUGATE_EVEN_STORAGE>& set_val) {
+        if (set_val == config_value::COMPLEX_COMPLEX) {
+            vals.conj_even_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Conjugate even storage must be complex_complex.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PLACEMENT, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PLACEMENT>& set_val) {
+        if (set_val == config_value::INPLACE || set_val == config_value::NOT_INPLACE) {
+            vals.placement = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Placement must be inplace or not inplace.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::INPUT_STRIDES, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::INPUT_STRIDES>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        std::copy(set_val, set_val + vals.rank + 1, vals.input_strides.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::OUTPUT_STRIDES, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::OUTPUT_STRIDES>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        std::copy(set_val, set_val + vals.rank + 1, vals.output_strides.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::FWD_DISTANCE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::FWD_DISTANCE>& set_val) {
+        vals.fwd_dist = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::BWD_DISTANCE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::BWD_DISTANCE>& set_val) {
+        vals.bwd_dist = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::WORKSPACE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::WORKSPACE>& set_val) {
+        if (set_val == config_value::ALLOW || set_val == config_value::AVOID) {
+            vals.workspace = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Workspace must be allow or avoid.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::ORDERING, prec, dom> {
+    static void set_val(dft_values<prec, dom>& vals,
+                        param_type_helper_t<real_helper_t<prec>, config_param::ORDERING>& set_val) {
+        if (set_val == config_value::ORDERED || set_val == config_value::BACKWARD_SCRAMBLED) {
+            vals.ordering = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Ordering must be ordered or backwards scrambled.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::TRANSPOSE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::TRANSPOSE>& set_val) {
+        vals.transpose = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PACKED_FORMAT, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PACKED_FORMAT>& set_val) {
+        if (set_val == config_value::CCE_FORMAT) {
+            vals.packed_format = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Packed format must be CCE.");
+        }
+    }
+};
+
+template <config_param Param, precision prec, domain dom>
+void set_value(dft_values<prec, dom>& vals,
+               param_type_helper_t<real_helper_t<prec>, Param> set_val) {
+    // Note, set_val argument cannot be a ref for use with va_arg.
+    set_value_helper<Param, prec, dom>::set_val(vals, set_val);
+}
+
+} // namespace detail
+} // namespace dft
+} // namespace mkl
+} // namespace oneapi
+
+#endif //_ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -67,12 +67,20 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*Buffer version*/                                                                                  \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
     template <>                                                                                         \
-    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(          \
-        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & inout) {        \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout) {           \
         detail::function_tables[get_device_id(desc.get_queue())]                                        \
-            .compute_forward_buffer_inplace_##EXT(desc, inout);                                         \
+            .compute_forward_buffer_inplace_real_##EXT(desc, inout);                                    \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(         \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_complex_##EXT(desc, inout);                                 \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -94,6 +102,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_forward_buffer_outofplace_##EXT(desc, in, out);                                    \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in,                \
+        sycl::buffer<T_REAL, 1> & out) {                                                                \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_real_##EXT(desc, in, out);                               \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT void                                                                                  \
@@ -107,14 +125,23 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*USM version*/                                                                                     \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
     template <>                                                                                         \
-    ONEMKL_EXPORT sycl::event                                                                           \
-    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(                             \
-        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,                           \
+    ONEMKL_EXPORT sycl::event compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(      \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,                              \
         const std::vector<sycl::event>& dependencies) {                                                 \
         return detail::function_tables[get_device_id(desc.get_queue())]                                 \
-            .compute_forward_usm_inplace_##EXT(desc, inout, dependencies);                              \
+            .compute_forward_usm_inplace_real_##EXT(desc, inout, dependencies);                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_complex_##EXT(desc, inout, dependencies);                      \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -136,6 +163,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_forward_usm_outofplace_##EXT(desc, in, out, dependencies);                         \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out,                   \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_real_##EXT(desc, in, out, dependencies);                    \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
@@ -149,12 +186,20 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*Buffer version*/                                                                                  \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout) {           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_real_##EXT(desc, inout);                                   \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex */                                                                   \
     template <>                                                                                         \
     ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(        \
         dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
         detail::function_tables[get_device_id(desc.get_queue())]                                        \
-            .compute_backward_buffer_inplace_##EXT(desc, inout);                                        \
+            .compute_backward_buffer_inplace_complex_##EXT(desc, inout);                                \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -176,6 +221,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_backward_buffer_outofplace_##EXT(desc, in, out);                                   \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in,                \
+        sycl::buffer<T_REAL, 1> & out) {                                                                \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_real_##EXT(desc, in, out);                              \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT void                                                                                  \
@@ -189,14 +244,24 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*USM version*/                                                                                     \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(                               \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,                              \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_real_##EXT(desc, inout, dependencies);                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
     compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                           \
         dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
         const std::vector<sycl::event>& dependencies) {                                                 \
         return detail::function_tables[get_device_id(desc.get_queue())]                                 \
-            .compute_backward_usm_inplace_##EXT(desc, inout, dependencies);                             \
+            .compute_backward_usm_inplace_complex_##EXT(desc, inout, dependencies);                     \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -219,6 +284,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_backward_usm_outofplace_##EXT(desc, in, out, dependencies);                        \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out,                   \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_real_##EXT(desc, in, out, dependencies);                   \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
@@ -230,12 +305,57 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                          dependencies);                                 \
     }
 
+// Signatures with forward_t=complex, backwards_t=complex are already instantiated for complex domain
+// but not real domain.
+#define ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(EXT, PRECISION, T_COMPLEX)                            \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT void                                                                            \
+    compute_forward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(      \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, sycl::buffer<T_COMPLEX, 1> & in, \
+        sycl::buffer<T_COMPLEX, 1> & out) {                                                       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                  \
+            .compute_forward_buffer_outofplace_complex_##EXT(desc, in, out);                      \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT sycl::event                                                                     \
+    compute_forward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(      \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, T_COMPLEX * in, T_COMPLEX * out, \
+        const std::vector<sycl::event>& dependencies) {                                           \
+        return detail::function_tables[get_device_id(desc.get_queue())]                           \
+            .compute_forward_usm_outofplace_complex_##EXT(desc, in, out, dependencies);           \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT void                                                                            \
+    compute_backward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(     \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, sycl::buffer<T_COMPLEX, 1> & in, \
+        sycl::buffer<T_COMPLEX, 1> & out) {                                                       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                  \
+            .compute_backward_buffer_outofplace_complex_##EXT(desc, in, out);                     \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT sycl::event                                                                     \
+    compute_backward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(     \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, T_COMPLEX * in, T_COMPLEX * out, \
+        const std::vector<sycl::event>& dependencies) {                                           \
+        return detail::function_tables[get_device_id(desc.get_queue())]                           \
+            .compute_backward_usm_outofplace_complex_##EXT(desc, in, out, dependencies);          \
+    }
+
 ONEAPI_MKL_DFT_SIGNATURES(f, dft::detail::precision::SINGLE, dft::detail::domain::REAL, float,
                           float, std::complex<float>)
+ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(f, dft::detail::precision::SINGLE, std::complex<float>)
 ONEAPI_MKL_DFT_SIGNATURES(c, dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX, float,
                           std::complex<float>, std::complex<float>)
 ONEAPI_MKL_DFT_SIGNATURES(d, dft::detail::precision::DOUBLE, dft::detail::domain::REAL, double,
                           double, std::complex<double>)
+ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(d, dft::detail::precision::DOUBLE, std::complex<double>)
 ONEAPI_MKL_DFT_SIGNATURES(z, dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX, double,
                           std::complex<double>, std::complex<double>)
 #undef ONEAPI_MKL_DFT_SIGNATURES

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -18,6 +18,8 @@
 *******************************************************************************/
 
 #include "oneapi/mkl/dft/detail/dft_loader.hpp"
+#include "oneapi/mkl/dft/forward.hpp"
+#include "oneapi/mkl/dft/backward.hpp"
 
 #include "function_table_initializer.hpp"
 #include "dft/function_table.hpp"
@@ -60,6 +62,184 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
 }
 
 } // namespace detail
+
+#define ONEAPI_MKL_DFT_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)                \
+                                                                                                        \
+    /*Buffer version*/                                                                                  \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(          \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & inout) {        \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_##EXT(desc, inout);                                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout_re,          \
+        sycl::buffer<T_REAL, 1> & inout_im) {                                                           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_split_##EXT(desc, inout_re, inout_im);                      \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>(                 \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & in,             \
+        sycl::buffer<T_BACKWARD, 1> & out) {                                                            \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_##EXT(desc, in, out);                                    \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in_re,             \
+        sycl::buffer<T_REAL, 1> & in_im, sycl::buffer<T_REAL, 1> & out_re,                              \
+        sycl::buffer<T_REAL, 1> & out_im) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im);         \
+    }                                                                                                   \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(                             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,                           \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_##EXT(desc, inout, dependencies);                              \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(      \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re, T_REAL * inout_im,        \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_split_##EXT(desc, inout_re, inout_im, dependencies);           \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>(                 \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in, T_BACKWARD * out,            \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_##EXT(desc, in, out, dependencies);                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re, T_REAL * in_im,              \
+        T_REAL * out_re, T_REAL * out_im, const std::vector<sycl::event>& dependencies) {               \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im,             \
+                                                        dependencies);                                  \
+    }                                                                                                   \
+                                                                                                        \
+    /*Buffer version*/                                                                                  \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_##EXT(desc, inout);                                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout_re,          \
+        sycl::buffer<T_REAL, 1> & inout_im) {                                                           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_split_##EXT(desc, inout_re, inout_im);                     \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>(                \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & in,            \
+        sycl::buffer<T_FORWARD, 1> & out) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_##EXT(desc, in, out);                                   \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in_re,             \
+        sycl::buffer<T_REAL, 1> & in_im, sycl::buffer<T_REAL, 1> & out_re,                              \
+        sycl::buffer<T_REAL, 1> & out_im) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im);        \
+    }                                                                                                   \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                           \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_##EXT(desc, inout, dependencies);                             \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(                               \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re, T_REAL * inout_im,        \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_split_##EXT(desc, inout_re, inout_im, dependencies);          \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>(                \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in, T_FORWARD * out,            \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_##EXT(desc, in, out, dependencies);                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re, T_REAL * in_im,              \
+        T_REAL * out_re, T_REAL * out_im, const std::vector<sycl::event>& dependencies) {               \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im,            \
+                                                         dependencies);                                 \
+    }
+
+ONEAPI_MKL_DFT_SIGNATURES(f, dft::detail::precision::SINGLE, dft::detail::domain::REAL, float,
+                          float, std::complex<float>)
+ONEAPI_MKL_DFT_SIGNATURES(c, dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX, float,
+                          std::complex<float>, std::complex<float>)
+ONEAPI_MKL_DFT_SIGNATURES(d, dft::detail::precision::DOUBLE, dft::detail::domain::REAL, double,
+                          double, std::complex<double>)
+ONEAPI_MKL_DFT_SIGNATURES(z, dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX, double,
+                          std::complex<double>, std::complex<double>)
+#undef ONEAPI_MKL_DFT_SIGNATURES
+
 } // namespace dft
 } // namespace mkl
 } // namespace oneapi

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -37,16 +37,20 @@ typedef struct {
     int version;
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_fz)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                                     oneapi::mkl::dft::domain::COMPLEX>& desc);
+                                     oneapi::mkl::dft::domain::COMPLEX>& desc,
+        sycl::queue& sycl_queue);
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dz)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
-                                     oneapi::mkl::dft::domain::COMPLEX>& desc);
+                                     oneapi::mkl::dft::domain::COMPLEX>& desc,
+        sycl::queue& sycl_queue);
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_fr)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
-                                     oneapi::mkl::dft::domain::REAL>& desc);
+                                     oneapi::mkl::dft::domain::REAL>& desc,
+        sycl::queue& sycl_queue);
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dr)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
-                                     oneapi::mkl::dft::domain::REAL>& desc);
+                                     oneapi::mkl::dft::domain::REAL>& desc,
+        sycl::queue& sycl_queue);
 
 #define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)   \
     void (*compute_forward_buffer_inplace_real_##EXT)(                                             \

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -47,6 +47,75 @@ typedef struct {
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dr)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                      oneapi::mkl::dft::domain::REAL>& desc);
+
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD) \
+    void (*compute_forward_buffer_inplace_##EXT)(                                                \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_FORWARD, 1> & inout);                                                     \
+    void (*compute_forward_buffer_inplace_split_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
+    void (*compute_forward_buffer_outofplace_##EXT)(                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                     \
+    void (*compute_forward_buffer_outofplace_split_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
+    sycl::event (*compute_forward_usm_inplace_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,       \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
+    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,          \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
+    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                   \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+        const std::vector<sycl::event>& dependencies);                                           \
+    void (*compute_backward_buffer_inplace_##EXT)(                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
+    void (*compute_backward_buffer_inplace_split_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
+    void (*compute_backward_buffer_outofplace_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                     \
+    void (*compute_backward_buffer_outofplace_split_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
+    sycl::event (*compute_backward_usm_inplace_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
+    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
+        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                  \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+        const std::vector<sycl::event>& dependencies);
+
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(f, oneapi::mkl::dft::detail::precision::SINGLE,
+                                      oneapi::mkl::dft::detail::domain::REAL, float, float,
+                                      std::complex<float>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(c, oneapi::mkl::dft::detail::precision::SINGLE,
+                                      oneapi::mkl::dft::detail::domain::COMPLEX, float,
+                                      std::complex<float>, std::complex<float>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(d, oneapi::mkl::dft::detail::precision::DOUBLE,
+                                      oneapi::mkl::dft::detail::domain::REAL, double, double,
+                                      std::complex<double>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(z, oneapi::mkl::dft::detail::precision::DOUBLE,
+                                      oneapi::mkl::dft::detail::domain::COMPLEX, double,
+                                      std::complex<double>, std::complex<double>)
+
+#undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES
 } dft_function_table_t;
 
 #endif //_DFT_FUNCTION_TABLE_HPP_

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -48,58 +48,94 @@ typedef struct {
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                      oneapi::mkl::dft::domain::REAL>& desc);
 
-#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD) \
-    void (*compute_forward_buffer_inplace_##EXT)(                                                \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_FORWARD, 1> & inout);                                                     \
-    void (*compute_forward_buffer_inplace_split_##EXT)(                                          \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
-    void (*compute_forward_buffer_outofplace_##EXT)(                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                     \
-    void (*compute_forward_buffer_outofplace_split_##EXT)(                                       \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
-        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_forward_usm_inplace_##EXT)(                                            \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,       \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                      \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
-        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
-    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                         \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,          \
-        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
-    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                   \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
-        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
-        const std::vector<sycl::event>& dependencies);                                           \
-    void (*compute_backward_buffer_inplace_##EXT)(                                               \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
-    void (*compute_backward_buffer_inplace_split_##EXT)(                                         \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
-    void (*compute_backward_buffer_outofplace_##EXT)(                                            \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                     \
-    void (*compute_backward_buffer_outofplace_split_##EXT)(                                      \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
-        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_backward_usm_inplace_##EXT)(                                           \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                     \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
-        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
-    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                        \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
-        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                          \
-    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                  \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
-        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)   \
+    void (*compute_forward_buffer_inplace_real_##EXT)(                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout);                                                          \
+    void (*compute_forward_buffer_inplace_complex_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                      \
+    void (*compute_forward_buffer_inplace_split_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                   \
+    void (*compute_forward_buffer_outofplace_##EXT)(                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                       \
+    void (*compute_forward_buffer_outofplace_real_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in, sycl::buffer<T_REAL, 1> & out);                              \
+    void (*compute_forward_buffer_outofplace_complex_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                      \
+    void (*compute_forward_buffer_outofplace_split_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                          \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                       \
+    sycl::event (*compute_forward_usm_inplace_real_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,            \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_inplace_complex_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,        \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,         \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,            \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_forward_usm_outofplace_real_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out, \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_outofplace_complex_##EXT)(                                   \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,            \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                          \
+        const std::vector<sycl::event>& dependencies);                                             \
+    void (*compute_backward_buffer_inplace_real_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout);                                                          \
+    void (*compute_backward_buffer_inplace_complex_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                      \
+    void (*compute_backward_buffer_inplace_split_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                   \
+    void (*compute_backward_buffer_outofplace_##EXT)(                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                       \
+    void (*compute_backward_buffer_outofplace_real_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in, sycl::buffer<T_REAL, 1> & out);                              \
+    void (*compute_backward_buffer_outofplace_complex_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                      \
+    void (*compute_backward_buffer_outofplace_split_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                          \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                       \
+    sycl::event (*compute_backward_usm_inplace_real_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,            \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_inplace_complex_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,        \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,         \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                            \
+    sycl::event (*compute_backward_usm_outofplace_real_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out, \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_outofplace_complex_##EXT)(                                  \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                    \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,            \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                          \
         const std::vector<sycl::event>& dependencies);
 
     ONEAPI_MKL_DFT_BACKEND_SIGNATURES(f, oneapi::mkl::dft::detail::precision::SINGLE,


### PR DESCRIPTION
* Adds MLKGPU backend
* Adds required work for enablement to common DFT code.
* Tested using modified examples from Intel's closed source MKL GPU library and prototype tests.
  * Incomplete testing mean that bugs may still exist.